### PR TITLE
Add tini init and run as node user

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches-ignore:
       - main
+  pull_request:
+    types: [opened, edited]
 
 jobs:
   test:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.1.4
+
+-   run Connector with `node` user instead of `root`
+-   run `tini` together with the Connector to ensure kernel events will be propagated to the Connector
+
 ## 2.1.3
 
 -> SDK 1.1.6

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,6 @@ RUN npm ci --production
 
 COPY --from=builder /usr/app/dist/ dist/
 
-USER node
-
 LABEL org.opencontainers.image.source = "https://github.com/nmshd/cns-connector"
 
 ENTRYPOINT ["/sbin/tini", "--"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN .ci/writeBuildInformation.sh
 
 FROM node:16.13.0-alpine
 ENV NODE_CONFIG_ENV=prod
+RUN apk add --no-cache tini
 WORKDIR /usr/app
 COPY config config
 COPY package.json package-lock.json ./
@@ -24,6 +25,9 @@ RUN npm ci --production
 
 COPY --from=builder /usr/app/dist/ dist/
 
+USER node
+
 LABEL org.opencontainers.image.source = "https://github.com/nmshd/cns-connector"
 
-ENTRYPOINT node ./dist/index.js
+ENTRYPOINT ["/sbin/tini", "--"]
+CMD ["node", "/usr/app/dist/index.js"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@nmshd/connector",
-	"version": "2.1.3",
+	"version": "2.1.4",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@nmshd/connector",
-			"version": "2.1.3",
+			"version": "2.1.4",
 			"license": "MIT",
 			"dependencies": {
 				"@js-soft/docdb-access-mongo": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nmshd/connector",
-    "version": "2.1.3",
+    "version": "2.1.4",
     "private": true,
     "description": "The Enmeshed Business Connector",
     "homepage": "https://enmeshed.eu/integrate",


### PR DESCRIPTION
Both is recommmended by the nodejs docker working group:
https://github.com/nodejs/docker-node/blob/main/docs/BestPractices.md

- Tini makes sure that kernel signals are handled properly, otherwise nodejs containers can take a while to shutdown sometimes.
- It is also recommended to run the container as non-root node user