### PR TITLE
The endpoint class is not exported from the SDK

### DIFF
--- a/packages/sdk/src/endpoints/index.ts
+++ b/packages/sdk/src/endpoints/index.ts
@@ -3,6 +3,7 @@ export * from "./AnnouncementsEndpoint";
 export * from "./AttributesEndpoint";
 export * from "./BackboneNotificationsEndpoint";
 export * from "./ChallengesEndpoint";
+export * from "./Endpoint";
 export * from "./FilesEndpoint";
 export * from "./IdentityMetadataEndpoint";
 export * from "./IncomingRequestsEndpoint";


### PR DESCRIPTION
# Readiness checklist

- [ ] I added/updated tests.
- [X] I ensured that the PR title is good enough for the changelog.
- [X] I labeled the PR.
- [X] I self-reviewed the PR.

# Description

Exporting the endpoint class would allow a clean import when extending the SDK.
