### PR TITLE
The `/monitoring/requests` route is authenticated with a non matching role

### DIFF
--- a/src/infrastructure/httpServer/HttpServer.ts
+++ b/src/infrastructure/httpServer/HttpServer.ts
@@ -271,7 +271,7 @@ export class HttpServer extends ConnectorInfrastructure<HttpServerConfiguration>
     }
 
     private useRequestsEndpoint() {
-        this.app.get("/Monitoring/Requests", routeRequiresAuthorization(this.#authenticator, "monitoring:responses"), (_: express.Request, res: express.Response) => {
+        this.app.get("/Monitoring/Requests", routeRequiresAuthorization(this.#authenticator, "monitoring:requests"), (_: express.Request, res: express.Response) => {
             res.status(200).json(this.requestTracker.getCount());
         });
     }


### PR DESCRIPTION
# Readiness checklist

- [ ] I added/updated tests.
- [ ] I ensured that the PR title is good enough for the changelog.
- [ ] I labeled the PR.
- [ ] I self-reviewed the PR.

<!-- # Description -->
