### PR TITLE
Remove explicit reference to typescript-ioc

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -2,5 +2,6 @@ pull_request_rules:
   - name: update pull request
     conditions:
       - label!=wip
+      - author!=renovate[bot]
     actions:
       update:

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
                 "@js-soft/ts-utils": "^2.3.7",
                 "@nmshd/connector-types": "*",
                 "@nmshd/runtime": "7.5.6",
-                "@nmshd/typescript-ioc": "3.2.5",
                 "@nmshd/typescript-rest": "^3.2.4",
                 "agentkeepalive": "4.6.0",
                 "amqplib": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,6 @@
         "@js-soft/ts-utils": "^2.3.7",
         "@nmshd/connector-types": "*",
         "@nmshd/runtime": "7.5.6",
-        "@nmshd/typescript-ioc": "3.2.5",
         "@nmshd/typescript-rest": "^3.2.4",
         "agentkeepalive": "4.6.0",
         "amqplib": "^2.0.1",


### PR DESCRIPTION
# Readiness checklist

- [x] I ensured that the PR title is good enough for the changelog.
- [x] I labeled the PR.
- [x] I added tests (if necessary).
- [x] I self-reviewed the PR.

# Description

The runtime already comes with typescript-ioc. If the connector also references it, and the version is not the same, then there are two instances of the container, which means that anything the runtime registers on the DI container is not accessible from the connector.

Removing the reference from the connector eliminates the risk of accidentally referencing a different version.
