### PR TITLE
Set npm dependency update team as Renovate and npm audit reviewer

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,13 +1,12 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": ["github>js-soft/renovate-config"],
-    "reviewers": ["Milena-Czierlinski", "britsta"],
+    "reviewers": ["team:npm-dependency-update-reviewers"],
     "packageRules": [
         {
             "groupName": "backbone",
             "matchPackageNames": ["ghcr.io/nmshd/backbone-*"],
-            "matchDatasources": ["docker"],
-            "additionalReviewers": ["tnotheis"]
+            "matchDatasources": ["docker"]
         }
     ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,12 +1,5 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": ["github>js-soft/renovate-config"],
-    "reviewers": ["team:npm-dependency-update-reviewers"],
-    "packageRules": [
-        {
-            "groupName": "backbone",
-            "matchPackageNames": ["ghcr.io/nmshd/backbone-*"],
-            "matchDatasources": ["docker"]
-        }
-    ]
+    "reviewers": ["team:npm-dependency-update-reviewers"]
 }

--- a/.github/workflows/dependency-security-maintenance.yml
+++ b/.github/workflows/dependency-security-maintenance.yml
@@ -10,5 +10,7 @@ permissions: {}
 jobs:
   npm-audit:
     uses: js-soft/github-actions/.github/workflows/dependency-security-maintenance.yml@902c2ae6951187b136fc378a2de6f64b41666015 # main
+    with:
+      reviewers: nmshd/npm-dependency-update-reviewers
     secrets:
       github-token: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
This PR routes Renovate and npm audit pull requests to the npm dependency update reviewers team.

Changes:
- replace existing Renovate reviewers with team:npm-dependency-update-reviewers
- pass nmshd/npm-dependency-update-reviewers to the dependency security maintenance workflow

Validation:
- parsed Renovate JSON with jq
- parsed workflow YAML with Ruby